### PR TITLE
Fixed issues in Safari and Firefox

### DIFF
--- a/src/schema-registry/export/export.controller.js
+++ b/src/schema-registry/export/export.controller.js
@@ -39,8 +39,6 @@ angularAPP.controller('ExportSchemasCtrl', function ($rootScope, $scope, env,Sch
       allZip.file(schema.subject +'.'+ schema.version + '.json', schema.schema);
   })  }, true);
 
-
-
   function bindEvent(el, eventName, eventHandler) {
     if (el.addEventListener){
       // standard way
@@ -51,33 +49,32 @@ angularAPP.controller('ExportSchemasCtrl', function ($rootScope, $scope, env,Sch
     }
   }
 
+  function downloadLatestSchemasWithBlob() {
+    latestZip.generateAsync({type:"blob"}).then(function (blob) {
+      saveAs(blob, "latestSchemas"+$scope.date+".zip");
+    }, function (err) {
+        latestLink.innerHTML += " " + err;
+    });
+    return false;
+  }
   var latestLink = document.getElementById('latestSchemas');
   if (JSZip.support.blob) {
-    function downloadWithBlob() {
-      latestZip.generateAsync({type:"blob"}).then(function (blob) {
-        saveAs(blob, "latestSchemas"+$scope.date+".zip");
-      }, function (err) {
-          latestLink.innerHTML += " " + err;
-      });
-      return false;
-    }
-    bindEvent(latestLink, 'click', downloadWithBlob);
+    bindEvent(latestLink, 'click', downloadLatestSchemasWithBlob);
   } else {
     latestLink.innerHTML += " (not supported on this browser)";
   }
 
-
+  function downloadAllSchemasWithBlob() {
+    allZip.generateAsync({type:"blob"}).then(function (blob) {
+      saveAs(blob, "allSchemas"+$scope.date+".zip");
+    }, function (err) {
+        allLink.innerHTML += " " + err;
+    });
+    return false;
+  }
   var allLink = document.getElementById('allSchemas');
   if (JSZip.support.blob) {
-    function downloadWithBlob() {
-      allZip.generateAsync({type:"blob"}).then(function (blob) {
-        saveAs(blob, "allSchemas"+$scope.date+".zip");
-      }, function (err) {
-          allLink.innerHTML += " " + err;
-      });
-      return false;
-    }
-    bindEvent(allLink, 'click', downloadWithBlob);
+    bindEvent(allLink, 'click', downloadAllSchemasWithBlob);
   } else {
     allLink.innerHTML += " (not supported on this browser)";
   }


### PR DESCRIPTION
SyntaxError: Strict mode does not allow function declarations in a lexically nested statement.

I tested this on Safari, Firefox, and Chrome on Mac, but no idea about anything on Windows.