### PR TITLE
Webpack 2 port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bower_components/
 node_modules/
 dist/
 .idea/
+schema-registry-ui.iml

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -53,9 +53,9 @@ module.exports = function (grunt) {
           'bower_components/ace-diff/libs/diff_match_patch.js',
           'bower_components/angular-json-tree/dist/angular-json-tree.min.js',
           'bower_components/angular-json-tree/dist/angular-json-tree.css',
-          "bower_components/Stuk/jszip=Stuk/jszip/dist/jszip.min.js",
-          "bower_components/Stuk/jszip=Stuk/jszip/vendor/FileSaver.js",
-          "bower_components/Stuk/jszip-utils=Stuk/jszip-utils/dist/jszip-utils.min.js"
+          'node_modules/jszip/dist/jszip.min.js',
+          'node_modules/jszip/vendor/FileSaver.js',
+          'node_modules/jszip-utils/dist/jszip-utils.min.js'
         ],
         dest: 'dist',
         expand: true

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -53,9 +53,9 @@ module.exports = function (grunt) {
           'bower_components/ace-diff/libs/diff_match_patch.js',
           'bower_components/angular-json-tree/dist/angular-json-tree.min.js',
           'bower_components/angular-json-tree/dist/angular-json-tree.css',
-          'bower_components/jszip/dist/jszip.min.js',
-          'bower_components/jszip/vendor/FileSaver.js',
-          'bower_components/jszip-utils/dist/jszip-utils.min.js'
+          "bower_components/Stuk/jszip=Stuk/jszip/dist/jszip.min.js",
+          "bower_components/Stuk/jszip=Stuk/jszip/vendor/FileSaver.js",
+          "bower_components/Stuk/jszip-utils=Stuk/jszip-utils/dist/jszip-utils.min.js"
         ],
         dest: 'dist',
         expand: true

--- a/bower.json
+++ b/bower.json
@@ -29,8 +29,6 @@
     "font-awesome": "fontawesome#^4.6.3",
     "angular-material-data-table": "^0.10.9",
     "ace-diff": "*",
-    "Stuk/jszip": "*",
-    "Stuk/jszip-utils": "*",
     "angular-diff-match-patch": "^0.2.4",
     "angular-json-tree": "^1.0.1"
 

--- a/index.html
+++ b/index.html
@@ -102,9 +102,10 @@ var clusters = [
 <script src="bower_components/angular-diff-match-patch/angular-diff-match-patch.js"></script>
 <script src="bower_components/ace-diff/libs/diff_match_patch.js"></script>
 <script src="bower_components/angular-json-tree/dist/angular-json-tree.min.js"></script>
-<script src="bower_components/Stuk/jszip=Stuk/jszip/dist/jszip.min.js"></script>
-<script src="bower_components/Stuk/jszip=Stuk/jszip/vendor/FileSaver.js"></script>
-<script src="bower_components/Stuk/jszip-utils=Stuk/jszip-utils/dist/jszip-utils.min.js"></script>
+<script src="node_modules/jszip/dist/jszip.min.js"></script>
+<script src="node_modules/jszip/vendor/FileSaver.js"></script>
+<script src="node_modules/jszip-utils/dist/jszip-utils.min.js"></script>
+
 <script src="env.js"></script>
 
 <!-- build:js combined.js -->

--- a/index.html
+++ b/index.html
@@ -102,10 +102,9 @@ var clusters = [
 <script src="bower_components/angular-diff-match-patch/angular-diff-match-patch.js"></script>
 <script src="bower_components/ace-diff/libs/diff_match_patch.js"></script>
 <script src="bower_components/angular-json-tree/dist/angular-json-tree.min.js"></script>
-<script src="bower_components/jszip/dist/jszip.min.js"></script>
-<script src="bower_components/jszip/vendor/FileSaver.js"></script>
-<script src="bower_components/jszip-utils/dist/jszip-utils.min.js"></script>
-
+<script src="bower_components/Stuk/jszip=Stuk/jszip/dist/jszip.min.js"></script>
+<script src="bower_components/Stuk/jszip=Stuk/jszip/vendor/FileSaver.js"></script>
+<script src="bower_components/Stuk/jszip-utils=Stuk/jszip-utils/dist/jszip-utils.min.js"></script>
 <script src="env.js"></script>
 
 <!-- build:js combined.js -->

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "A user interface for Confluent's Schema Registry",
   "readme": "README.md",
   "main": "Gruntfile.js",
-  "dependencies": {},
+  "dependencies": {
+    "jszip": "^3.1.3",
+    "jszip-utils": "0.0.2"
+  },
   "devDependencies": {
     "grunt": "^1.0.1",
     "grunt-bower-task": "^0.4.0",


### PR DESCRIPTION
Implemented webpack 2 for building project. Npm is now used for both dev and project dependencies.
Output consists of vendor.js and app.js bundles.
Uses webpack-dev-server for automatic compilation and reload.
Supports ES2015.
Builds and server run in dev or production mode. Additional optimisations can added later.
Minimal code changes done, mainly requiring libs or modifying code in order to support dependency injection post-minification.
Needs cleaning of gruntfile.
