### PR TITLE
Fixing bug that wrongfully marked Avro schemas with enum types as invalid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schema-registry-ui",
-  "version": "0.9.2",
+  "version": "0.9.1",
   "description": "A user interface for Confluent's Schema Registry",
   "readme": "README.md",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schema-registry-ui",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "A user interface for Confluent's Schema Registry",
   "readme": "README.md",
   "dependencies": {

--- a/src/schema-registry/new/new.controller.js
+++ b/src/schema-registry/new/new.controller.js
@@ -55,7 +55,7 @@ var NewSubjectCtrl = function ($scope, $route, $rootScope, $http, $log, $q, $loc
    * 3. new-schema      -> Schema is Json + subject does not exist
    */
   $scope.allowCreateOrEvolution = false;
-  var validTypes = ["null", "double", "string", "record", "int", "float", "long", "array", "boolean", "enum", "map", "fixed", "bytes", "type"];
+  var validTypes = ["null", "double", "string", "record", "int", "float", "long", "array", "boolean", "enum", "map", "fixed", "bytes", "type", "symbols"];
   var primitiveTypes = ["null", "boolean", "int", "long", "float", "double", "bytes", "string"];
 
   function testCompatibility(subject, newAvroString) {
@@ -103,33 +103,85 @@ var NewSubjectCtrl = function ($scope, $route, $rootScope, $http, $log, $q, $loc
     };
 
     var obj = flattenObject(newAvroString);
-    for (var key in obj) {
-      if (key.indexOf('type') !== -1) {
-        var primType = getPrimitiveType(key);
-        if (primType !== -1) {
-          if (validTypes.indexOf(obj[key]) < 0) {
-            $scope.wrongType = obj[key];
-            $scope.notValidType = true;
-          }
-        }
+    var typeKeysToCheck = Object.keys(obj)
+      .reduce(function (typeKeys, key, idx) {
+        // Check that this string has a type substring, if not, we don't have to validate
+        if (key.indexOf('type') !== -1 && isPrimitiveTypeKey(key)) {
+          typeKeys.push(key);
+        } 
+
+        return typeKeys;
+      }, []);
+
+    var typeKeysToCheckLength = typeKeysToCheck.length;
+
+    // Create for loop vars
+    var i;
+    var keyToCheck;
+
+    /* 
+     * By iterating in a for loop, we can break out of an invalid key type found immediately.
+     * That way the UI shows each wrong type one by one(if there are many) instead of just the last
+     * one.
+     */
+    for (i = 0; i < typeKeysToCheckLength; i++) {
+      keyToCheck = typeKeysToCheck[i];
+
+      if (validTypes.indexOf(obj[keyToCheck]) < 0) {
+        $scope.wrongType = obj[keyToCheck];
+        $scope.notValidType = true;
+
+        break;
       }
+    }
+
+    function isKeyType(key) {
+      return key === 'type';
+    }
+
+    function checkLastTwoKeyParts(lastKeyPart, nextToLastKeyPart) {
+      var isLastKeyPartNotANumber = isNaN(lastKeyPart);
+
+      // If it is not a number, then make sure it's a type key
+      if (isLastKeyPartNotANumber) {
+        return isKeyType(lastKeyPart);
+      }
+
+      // If the last part was a number, is the next to last a type part?
+      return isKeyType(nextToLastKeyPart);
+    };
+
+    // Check if they key is actually a key that defines the primitive type
+    function isPrimitiveTypeKey(key) {
+      var keyToArray = key.split('.');
+      var keyToArrayLength = keyToArray.length;
+      var lastKeyPart = keyToArray[keyToArrayLength - 1];
+      var nextToLastKeyPart = keyToArray[keyToArrayLength - 2];
+
+      return keyToArrayLength === 1 || checkLastTwoKeyParts(lastKeyPart, nextToLastKeyPart);
     }
 
     function getPrimitiveType(key) {
 
       var keyToArray = key.split('.');
+      var keysToArrayLength = keyToArray.length;
+
       var index;
-      if (keyToArray.length === 1) {
+
+      if (keysToArrayLength === 1) {
         index = 0
       } else {
-        if (isNaN(keyToArray[keyToArray.length - 1])) {
-          if ((keyToArray[keyToArray.length - 1] === 'type')) {
-            index = keyToArray.length - 1
+        var lastKeyIdx = keysToArrayLength - 1;
+        var lastKey = keyToArray[keysToArrayLength - 1];
+
+        if (isNaN(lastKey)) {
+          if ((lastKey === 'type')) {
+            index = lastKeyIdx;
           } else {
             return -1;
           }
         } else {
-          index = keyToArray.length - 2
+          index = keysToArrayLength - 2
         }
       }
 
@@ -377,3 +429,4 @@ var NewSubjectCtrl = function ($scope, $route, $rootScope, $http, $log, $q, $loc
 NewSubjectCtrl.$inject = ['$scope', '$route', '$rootScope', '$http', '$log', '$q', '$location', 'UtilsFactory', 'SchemaRegistryFactory', 'toastFactory', 'env']
 
 angularAPP.controller('NewSubjectCtrl', NewSubjectCtrl);
+

--- a/src/schema-registry/new/new.controller.js
+++ b/src/schema-registry/new/new.controller.js
@@ -55,7 +55,7 @@ var NewSubjectCtrl = function ($scope, $route, $rootScope, $http, $log, $q, $loc
    * 3. new-schema      -> Schema is Json + subject does not exist
    */
   $scope.allowCreateOrEvolution = false;
-  var validTypes = ["null", "double", "string", "record", "int", "float", "long", "array", "boolean", "enum", "map", "fixed", "bytes", "type", "symbols"];
+  var validTypes = ["null", "double", "string", "record", "int", "float", "long", "array", "boolean", "enum", "map", "fixed", "bytes", "type"];
   var primitiveTypes = ["null", "boolean", "int", "long", "float", "double", "bytes", "string"];
 
   function testCompatibility(subject, newAvroString) {

--- a/src/schema-registry/new/new.controller.js
+++ b/src/schema-registry/new/new.controller.js
@@ -161,34 +161,6 @@ var NewSubjectCtrl = function ($scope, $route, $rootScope, $http, $log, $q, $loc
       return keyToArrayLength === 1 || checkLastTwoKeyParts(lastKeyPart, nextToLastKeyPart);
     }
 
-    function getPrimitiveType(key) {
-
-      var keyToArray = key.split('.');
-      var keysToArrayLength = keyToArray.length;
-
-      var index;
-
-      if (keysToArrayLength === 1) {
-        index = 0
-      } else {
-        var lastKeyIdx = keysToArrayLength - 1;
-        var lastKey = keyToArray[keysToArrayLength - 1];
-
-        if (isNaN(lastKey)) {
-          if ((lastKey === 'type')) {
-            index = lastKeyIdx;
-          } else {
-            return -1;
-          }
-        } else {
-          index = keysToArrayLength - 2
-        }
-      }
-
-      return keyToArray[index];
-    }
-
-
     newAvroString = JSON.stringify(newAvroString);
 
     var deferred = $q.defer();


### PR DESCRIPTION
The bug happened when a schema type with an enum was being created. It always marked the last value of the symbol's array as "not valid"

This happened because the validation did not consider the situation when a flattened key's last character was a number and the next to last word was "symbols"

It always assumed that if the last word after breaking up the flattened key was a number, the previous word must be "type"

Also refactored some of the code to be a bit more clear. Now the validation stops after the first invalid type. That way it doesn't iterate through all of them if there are multiple and only display the last one.