### PR TITLE
fix: prevent creation of schemas in readonly mode

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -73,7 +73,7 @@ var clusters = [
      $GLOBAL_SETTING
      $TRANSITIVE_SETTING
      $DELETION_SETTING
-     $READONLY_SETTTING
+     $READONLY_SETTING
    }
 ]
 EOF

--- a/src/schema-registry/home/home.controller.js
+++ b/src/schema-registry/home/home.controller.js
@@ -3,6 +3,7 @@ var angularAPP = angular.module('angularAPP');
 
 var HomeCtrl = function ($log, SchemaRegistryFactory, toastFactory, $scope, env) {
   $log.info("Starting schema-registry controller - home");
+  $scope.readonlyMode = env.readonlyMode();
   toastFactory.hideToast();
 
   $scope.$watch(function () {

--- a/src/schema-registry/home/home.html
+++ b/src/schema-registry/home/home.html
@@ -2,7 +2,7 @@
   <div class="row-fluid">
     <div >
       <p> Welcome to the <b>schema registry ui</b></p><br/>
-      <p> select a schema or <a ng-href="#/cluster/{{cluster}}/schema/new">create a new one</a></p><br/>
+        <p> select a schema<span ng-hide="readonlyMode"> or <a ng-href="#/cluster/{{cluster}}/schema/new">create a new one</a></span></p><br/>
     </div>
   </div>
 </div>

--- a/src/schema-registry/list/list.controller.js
+++ b/src/schema-registry/list/list.controller.js
@@ -4,6 +4,7 @@ var angularAPP = angular.module('angularAPP');
 var SubjectListCtrl = function ($scope, $rootScope, $log, $mdMedia, SchemaRegistryFactory, env) {
 
   $log.info("Starting schema-registry controller : list ( initializing subject cache )");
+  $scope.readonlyMode = env.readonlyMode();
 
   function addCompatibilityValue() {
     angular.forEach($rootScope.allSchemas, function (schema) {
@@ -38,6 +39,7 @@ var SubjectListCtrl = function ($scope, $rootScope, $log, $mdMedia, SchemaRegist
     return env.getSelectedCluster().NAME;
   }, function (a) {
     $scope.cluster = env.getSelectedCluster().NAME;
+    $scope.readonlyMode = env.readonlyMode();
     loadCache(); //When cluster change, reload the list
   }, true);
   /**

--- a/src/schema-registry/list/list.html
+++ b/src/schema-registry/list/list.html
@@ -5,7 +5,7 @@
         <span>{{allSchemas.length}} Schemas</span>
       </h3>
       <span flex></span>
-      <a md-ink-ripple ng-show="true" ng-href="#/cluster/{{cluster}}/schema/new"
+      <a md-ink-ripple ng-hide="readonlyMode" ng-href="#/cluster/{{cluster}}/schema/new"
          class="md-raised md-primary md-button md-ink-ripple blue"
          type="button"
          aria-label="new connector">New</a>

--- a/src/schema-registry/new/new.controller.js
+++ b/src/schema-registry/new/new.controller.js
@@ -59,6 +59,13 @@ var NewSubjectCtrl = function ($scope, $route, $rootScope, $http, $log, $q, $loc
   var primitiveTypes = ["null", "boolean", "int", "long", "float", "double", "bytes", "string"];
 
   function testCompatibility(subject, newAvroString) {
+    if (env.readonlyMode()) {
+      var deferred = $q.defer();
+      $scope.showSimpleToastToTop("Creation is not allowed in readonly mode");
+      deferred.resolve("readonly");
+      return deferred.promise;
+    }
+
     $scope.notValidType = false;
 
     if (newAvroString === "null") {
@@ -271,13 +278,14 @@ var NewSubjectCtrl = function ($scope, $route, $rootScope, $http, $log, $q, $loc
     var subject = $scope.text;
     testCompatibility(subject, $scope.newAvroString).then(
       function success(response) {
-        // no-subject-name | not-json | new-schema | compatible | non-compatible | failure
+        // no-subject-name | not-json | new-schema | compatible | non-compatible | failure | readonly
         switch (response) {
           case "no-subject-name":
           case "not-json":
           case "not-valid-type":
           case "failure":
           case "non-compatible":
+          case "readonly":
             $log.debug("registerNewSchema - cannot do anything more with [ " + response + " ]");
             break;
           case 'new-schema':


### PR DESCRIPTION
This pull request allows to fix 2 issues linked to readonly feature:

- creation of schemas was still allowed in readonly mode (button shown + validation not blocked in case of direct access to /schema/new)
- readonly mode not correctly set in env.js by run.sh script in docker (due to typo in READONLY_SETTING variable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/schema-registry-ui/89)
<!-- Reviewable:end -->
