### PR TITLE
Extend CORS explanations and include a sample docker compose file

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -59,10 +59,15 @@ Caddy server will proxy the traffic to Schema Registry:
 > IP address or a domain that can be resolved to it. **You can't use**
 > `localhost` even if you serve Schema Registry from your localhost. The reason
 > for this is that a docker container has its own network, so your _localhost_
-> is different from the container's _localhost_. As an example, if you are in
-> your home network and have an IP address of `192.168.5.65` and run Schema
-> Registry from your computer, instead of `http://127.0.1:8082` you must use
-> `http://192.168.5.65:8082`.
+> is different from the container's _localhost_. 
+> To remedy this you need to specify
+> the registry's container hostname via `--hostname` parameter. In 
+> addition, the `SCHEMA_REGISTRY_HOST_NAME` and `SCHEMA_REGISTRY_LISTENERS`
+> environment variables need to be set.
+> 
+> For an example see the [docker-compose.yml](docker-compose.yml) file. Running
+> `docker-compose up` will spin up a schema registry, the schema registry UI 
+> (available at http://localhost:8000) as well as a Kafka broker and Zookeeper.
 
 If your Schema Registry uses self-signed SSL certificates, you can use the
 `PROXY_SKIP_VERIFY=true` environment variable to instruct the proxy to

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '2.1'
+services:
+
+  schema-registry-ui:
+    image: landoop/schema-registry-ui
+    hostname: schema-registry-ui
+    depends_on:
+    - schema-registry
+    environment:
+    - SCHEMAREGISTRY_URL=http://schema-registry:8081
+    - PROXY=true
+    ports:
+    - 8000:8000
+
+  schema-registry:
+    image: confluentinc/cp-schema-registry
+    hostname: schema-registry
+    environment:
+      - SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=zookeeper:2181
+      - SCHEMA_REGISTRY_HOST_NAME=schema-registry
+      - SCHEMA_REGISTRY_LISTENERS=http://schema-registry:8081
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper
+    hostname: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+
+  kafka:
+    image: confluentinc/cp-kafka
+    hostname: kafka
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://kafka:9092
+


### PR DESCRIPTION
The suggested solution to the CORS issue is not ideal, IMO. I added a docker compose file that demonstrates how you can run the UI and a schema registry locally without dealing with IPs