### PR TITLE
Removed  string that stopped update subject compatibility

### DIFF
--- a/src/factories/schema-registry-factory.js
+++ b/src/factories/schema-registry-factory.js
@@ -326,7 +326,7 @@ var SchemaRegistryFactory = function ($rootScope, $http, $location, $q, $log, Ut
       var putConfig = {
         method: 'PUT',
         url: env.SCHEMA_REGISTRY() + '/config/' + subjectName,
-        data: '{"compatibility":"' + newCompatibilityLevel + '"}' + "'",
+        data: '{"compatibility":"' + newCompatibilityLevel + '"}',
         dataType: 'json',
         headers: {'Content-Type': 'application/json', 'Accept': 'application/json'}
       };


### PR DESCRIPTION
The body of the requests when trying to change the  compatibility for a subject was like:
`{"compatibility": "BACKWARDS"}'` with a trailing `'`, which makes the request fail.